### PR TITLE
add Medley-solos-DB to mir-datasets.yaml

### DIFF
--- a/mir-datasets.yaml
+++ b/mir-datasets.yaml
@@ -692,6 +692,13 @@ MedleyDB:
     - instrument activation
   contents: 122 songs
   audio: 'yes'
+  
+Medley-solos-DB:
+   title: "Medley-solos-DB: a cross-collection dataset for musical instrument recognition"
+   url: https://zenodo.org/record/2582103
+   metadata: 8 instruments
+   contents: 21572 excerpts
+   audio: 'yes'
 
 MIR-1K:
   url: https://sites.google.com/site/unvoicedsoundseparation/mir-1k


### PR DESCRIPTION
Medley-solos-DB is a cross-collection dataset for automatic musical instrument recognition in solo recordings. It consists of a training set of 3-second audio clips, which are extracted from the MedleyDB dataset of Bittner et al. (ISMIR 2014) as well as a test set  of 3-second clips, which are extracted from the solosDB dataset of Essid et al. (IEEE TASLP 2009). Each of these clips contains a single instrument among a taxonomy of eight: clarinet, distorted electric guitar, female singer, flute, piano, tenor saxophone, trumpet, and violin.

The Medley-solos-DB dataset is the dataset that is used in the benchmarks of musical instrument recognition in the publications of Lostanlen and Cella (ISMIR 2016) and Andén et al. (IEEE TSP 2019).