### PR TITLE
Ejhumphrey/url check fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,30 @@
 sudo: false
-
 cache:
-    directories:
-        - $HOME/env
-
+  directories:
+  - "$HOME/env"
 language: python
-
 python:
-    - "3.6"
-
+- '3.6'
 before_install:
-    - bash .travis_dependencies.sh
-    - export PATH="$HOME/env/miniconda$TRAVIS_PYTHON_VERSION/bin:$PATH";
-    - hash -r
-    - source activate test-environment
-
+- bash .travis_dependencies.sh
+- export PATH="$HOME/env/miniconda$TRAVIS_PYTHON_VERSION/bin:$PATH";
+- hash -r
+- source activate test-environment
 install:
-    - pip install -r tests/requirements.txt
-
+- pip install -r tests/requirements.txt
 script:
-    - python --version
-    - py.test tests -v
+- python --version
+- py.test tests -v
+- ./render_datasets.py mir-datasets.yaml outputs/data-sets.md
+- ./render_datasets.py mir-datasets.yaml outputs/mir-datasets.js
+env:
+  global:
+    secure: ft5VtuoE8/Zn++w7qhRDsBBW0tzYrB/4vq1ViRHyqLoooWjCh7/x/JL7EevZ3+Tj3V7iv5ygh+As6E0q/Gls235u17GPJ/voNuZgtQ8jODNncYYNjl8diQuJJNCisjLQrwyKMA8RN25tvppN0zvimp2roCI0sPJMzMmN00+8vxtxJZ/MHADaclXOkc8msDLqBfcvBmflhD1R2zg57z4jT/t1a0BXwBL4eYQ66mFQAmM51sV7qV+ef8O1jlk1Jh0IcpLGmH5EvoolEuUpFcgVgRwtovcB21fRR7JEcTRpCScImVrfbpq0+AVxHQNcGhcEQFv9ZDyNWaQn/fI73JtwqAnGKCvDWKb5MC9FrPtAK+VqleiBGX7Rm1UFCVI0gi664OMkiOfb7BfvcRlvs9cOj3HToUh8/h5ubO6l/3Qde4lq8TvfgA5dmQ1sgaIjR7C8Gi7r2d0n4Rq07k9xah07zuZg8rhEl4t6TwYGzAWRVjp3ENOe6kxgXG9SaKkVmt/r4KIK3kanYQcpx9Q66JwPNkg57Ff9PwqLoWFCk7mio5/t1s9F029N5h2pfPHACNTCQIps6V/TwpHy9SEkuj24uWQ5+cblcdm3Ye3f4qkQRntFV5fyruWtmsV+t+fYSkngZ3YPIvtJ0GwEpeDnBWvrE1jJ0eLQZwMmvzECYNG12Qw=
+
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN
+  keep_history: true
+  on:
+    branch: master

--- a/README.md
+++ b/README.md
@@ -54,16 +54,28 @@ adhere to the following:
 
 ## Scripts
 
-For now, the only output format supported is Markdown, which you can obtain via the following:
+You can render the output as either Markdown or Javascript by specifying the correct output format, via the following:
 
 ```bash
-$ ./render_datasets.py mir-datasets.yaml datasets.md
+$ ./render_datasets.py mir-datasets.yaml outputs/mir-datasets.js
 ```
 
-Which will produce the output [data-sets.md](https://github.com/ismir/mir-datasets/blob/master/outputs/data-sets.md) file contained in this repository. Note that this output file **should not** be modified directly:
+Which will produce the output [data-sets.md](https://github.com/ismir/mir-datasets/blob/master/outputs/mir-datasets.js) file contained in this repository. Note that this output file **should not** be modified directly:
 
 * If the information is incorrect, update the source YAML file
 * If the formatting is wrong, please help fix the script (or [open an issue](https://github.com/ismir/mir-datasets/issues))
+
+
+## Testing
+
+You can verify that the JS table is produced correctly by running a local HTTP server from the repository root, which points to `index.html`. 
+
+```bash
+python -m http.server
+```
+
+Note that the table will inherit the CSS of the page that renders it. 
+
 
 ## ISMIR-Home
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,3 @@
+<body>
+<script src="outputs/mir-datasets.js"></script>
+</body>

--- a/render_datasets.py
+++ b/render_datasets.py
@@ -59,7 +59,7 @@ def render_one(key, record):
                                   status=status, **record)
 
 
-def render(records, output_format, n_jobs=-1):
+def render(records, output_format, n_jobs=-1, verbose=0):
     '''Render a number of records to the given output format.
 
     Parameters
@@ -75,10 +75,10 @@ def render(records, output_format, n_jobs=-1):
     data : str
         String data to write to file.
     '''
-    records = sorted(records.items(), key=lambda x: x[0].lower())[:10]
+    records = sorted(records.items(), key=lambda x: x[0].lower())
     
     # Fan out
-    pool = joblib.Parallel(n_jobs=n_jobs, verbose=20)
+    pool = joblib.Parallel(n_jobs=n_jobs, verbose=verbose)
     dfx = joblib.delayed(render_one)
     lines = pool(dfx(key, record) for key, record in records)
 
@@ -108,12 +108,16 @@ if __name__ == '__main__':
     parser.add_argument("--n_jobs",
                         metavar="n_jobs", type=int, default=1,
                         help="Number of CPUs to use for parallelization (-1 for all).")
+    parser.add_argument("--verbose",
+                        metavar="verbose", type=int, default=0,
+                        help="Verbosity level, 0 for nothing, >1 for something.")
 
     args = parser.parse_args()
     dataset = yaml.load(open(args.dataset_file))
 
     output_format = os.path.splitext(args.output_file)[-1].strip('.')
     with open(args.output_file, 'w') as fp:
-        fp.write(render(dataset, output_format, n_jobs=args.n_jobs))
+        fp.write(render(dataset, output_format, 
+                        n_jobs=args.n_jobs, verbose=args.verbose))
 
     sys.exit(0 if os.path.exists(args.output_file) else 1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 PyYAML
 Markdown
+joblib

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,3 @@
 pytest
 PyYAML
 pytest-tldr
-fake-useragent

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,11 +1,10 @@
-import yaml
-import urllib.request
 import pytest
-from fake_useragent import UserAgent
 
+import urllib.request
+from urllib.error import HTTPError
+import warnings
+import yaml
 
-# get fake user agent
-ua = UserAgent()
 
 # open dataset file
 with open('mir-datasets.yaml', 'rb') as hdl:
@@ -46,8 +45,6 @@ def test_metadata(dataset):
 def test_url(dataset):
     values = dataset[1]
 
-    # check if website is up
-    req = urllib.request.Request(values['url'], headers={'User-Agent' : ua.random}) 
-    code = urllib.request.urlopen(req, timeout=5).getcode()
+    parts = urllib.parse.urlparse(values['url'])
+    assert parts.scheme.startswith('http')
 
-    assert (code == 200)


### PR DESCRIPTION
Does two things (my b, I couldn't help myself):

1. Important one: updates testing tools only check that URLs look like well formed URLs. URL `get`s have been moved into `render_datasets.py` so that rows in the table get marked as ✅ or ☠️ depending on the HTTP response. 
2. also sets up a `gh-pages` deploy on pushes to master so we don't have to manually update the assets in the repo

I've (semi)intentionally left out the timestamp for the table, as that seems like potentially follow-up work and I'm not sure where it'd go. Thoughts?