### PR TITLE
add TinySOL dataset

### DIFF
--- a/mir-datasets.yaml
+++ b/mir-datasets.yaml
@@ -1186,6 +1186,17 @@ ThisIsMyJam:
     - artists
   contents: 131k users
   audio: 'no'
+  
+ TinySOL:
+  url: https://zenodo.org/record/3632192
+  title: TinySOL: an audio dataset of isolated musical notes
+  metadata:
+    - instrument
+    - pitch
+    - dynamics
+    - string number (if applicable)
+  contents: 2913 isolated notes
+  audio: 'yes'
 
 TONAS:
   url: http://mtg.upf.edu/download/datasets/tonas


### PR DESCRIPTION
TinySOL is a dataset of 2478 samples, each containing a single musical note from one of 14 different instruments:

    Bass Tuba
    French Horn
    Trombone
    Trumpet in C
    Accordion
    Contrabass
    Violin
    Viola
    Violoncello
    Bassoon
    Clarinet in B-flat
    Flute
    Oboe
    Alto Saxophone

These sounds were originally recorded at Ircam in Paris (France) between 1996 and 1999, as part of a larger project named Studio On Line (SOL). Although SOL contains many combinations of mutes and extended playing techniques, TinySOL purely consists of sounds played in the so-called "ordinary" style, and in absence of mute.

TinySOL can be used for creative purposes insofar at the use complies with the Creative Commons Attribution 4.0 International license (see below).

TinySOL can be used for education and research purposes. In particular, it can be employed as a dataset for training and/or evaluating music information retrieval (MIR) systems, for tasks such as instrument recognition or fundamental frequency estimation. For this purpose, we provide an official 5-fold split of TinySOL. This split has been carefully balanced in terms of instrumentation, pitch range, and dynamics. For the sake of research reproducibility, we encourage users of TinySOL to adopt this split and report their results in terms of average performance across folds.

(this PR is part of an under-review paper to ICMC)