### PR TITLE
Added FSLD to the list of datasets

### DIFF
--- a/mir-datasets.yaml
+++ b/mir-datasets.yaml
@@ -419,6 +419,13 @@ FMA-full:
   contents: 106574 songs
   audio: 'yes'
 
+Freesound-Loop-Dataset:
+  url: https://zenodo.org/record/3967852
+  metadata: tempo, key, instrumentation, genre
+  contents: 3000 annotated loops, 9455 loops total
+  audio: 'yes'
+
+
 FSD-Kaggle2019:
   url: https://zenodo.org/record/3612637
   metadata: 80 tags


### PR DESCRIPTION
Added an entry on the mir-datasets list for the Freesound Loop Dataset:
 - Dataset: https://zenodo.org/record/3967852
 - Publication: Ramires, A., F. Font, D. Bogdanov, J. B. L. Smith, Y.-H. Yang, J. Ching, B.-Y. Chen, Y.-K. Wu, H. Wei-Han, and X. Serra. 2020. The Freesound Loop Dataset and Annotation Tool. In Proceedings of the International Society for Music Information Retrieval Conference. 287–94. Montreal, QC, Canada.