### PR TITLE
Added AAM dataset entry

### DIFF
--- a/mir-datasets.yaml
+++ b/mir-datasets.yaml
@@ -4,6 +4,21 @@
   contents: 7371 one-shots
   audio: 'yes'
   
+AAM:
+  url: https://zenodo.org/record/5794629
+  metadata:
+    - onsets
+    - pitches
+    - instruments
+    - melody instrument
+    - keys
+    - chords
+    - tempos
+    - beats
+    - segments
+  contents: 3,000 music tracks (with single instrument multitracks)
+  audio: 'yes'
+
 AccoMontage2:
   url: https://github.com/billyblu2000/accomontage2
   metadata: song harmonization and accompaniment arrangement based on a lead melody


### PR DESCRIPTION
This dataset was published in EURASIP Journal on Audio, Speech, and Music Processing in this year (2023): https://doi.org/10.1186/s13636-023-00278-7
The data is stored here: https://zenodo.org/record/5794629
I hope the dataset fits well with your list and the entry was added to the .yaml file in the correct way with respect to your requirements.
Thanks in advance, feel free to ask anything about it or modify the entry in any way if necessary.
