### PR TITLE
Add Song Describer Dataset

### DIFF
--- a/mir-datasets.yaml
+++ b/mir-datasets.yaml
@@ -1558,6 +1558,12 @@ SMD:
   contents: 50 recordings
   audio: 'yes'
 
+SongDescriberDataset:
+  url: https://doi.org/10.5281/zenodo.10072001
+  metadata: descriptive captions
+  contents: 706 music recordings (2 min)
+  audio: 'yes'
+
 SongInterpretationDataset:
   url: https://zenodo.org/record/7019124#.Y5yxwux_pTY
   metadata: lyrics 


### PR DESCRIPTION
Added the [Song Describer Dataset (SDD)](https://github.com/mulab-mir/song-describer-dataset), a collection of 1106 crowdsourced captions describing 706 music recordings, both released under CC licences. 