### PR TITLE
Remove space at beginning of line

### DIFF
--- a/mir-datasets.yaml
+++ b/mir-datasets.yaml
@@ -1040,7 +1040,7 @@ MER500:
    contents: 500 clips
    audio: 'yes'
 
- MidiCaps:
+MidiCaps:
   url: https://huggingface.co/datasets/amaai-lab/MidiCaps
   title: MidiCaps
   metadata:


### PR DESCRIPTION
Hi! 
Thanks for the great repo! I tried using the `.yaml` file but I got errors because it was "wrongly formatted".
There was indeed a space at the beginning of a line that broke indentation.