### PR TITLE
Add Yambda dataset to mir-datasets.yaml

### DIFF
--- a/mir-datasets.yaml
+++ b/mir-datasets.yaml
@@ -1819,6 +1819,16 @@ RobbieWilliamsAnnotations:
     - beats
   contents: 65 songs
   audio: 'no'
+
+Yambda:
+  url: https://huggingface.co/datasets/yandex/yambda
+  metadata:
+    - user-item interactions
+    - implicit feedback
+    - explicit feedback
+    - organic vs recommendation markers
+  contents: 4.79B interactions, 1M users, 9.39M tracks (slices: 500M, 50M)
+  audio: 'no'
   
 YM2413-MDB:
   url: https://github.com/jech2/YM2413-MDB


### PR DESCRIPTION
This PR adds Yambda (industrial-scale music recommendation dataset) entry to mir-datasets.yaml.

- URL: https://huggingface.co/datasets/yandex/yambda
- Metadata: user-item interactions, implicit & explicit feedback, organic markers
- Contents: 4.79B interactions, 1M users, 9.39M tracks (plus 500M and 50M slices)
- Audio: 'no'
